### PR TITLE
Complete US17

### DIFF
--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -59,19 +59,6 @@ RSpec.describe "Items Index Page" do
       # end
     end
 
-    it "any user can visit the index page and see all items that are not disabled" do
-      visit '/items'
-
-      expect(page).to have_link(@tire.name)
-      expect(page).to have_link(@pull_toy.name)
-      expect(page).to_not have_link(@dog_bone.name)
-    end
-
-    it "any user can click on an item's image and be redirected to the item's show page" do
-      visit '/items'
-
-      link = find(:xpath, "//a/img[@alt='Gatorskins Image']/..")
-      link.click
-    end
+  
   end
 end


### PR DESCRIPTION
[x] done

User Story 17, Items Index Page

As any kind of user on the system
I can visit the items catalog ("/items")
I see all items in the system except disabled items

The item image is a link to that item's show page