### PR TITLE
Story33

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,9 @@
+class Admin::OrdersController < Admin::BaseController
+
+  def update
+    order = Order.find(params[:order_id])
+    order.update(status: 2)
+
+    redirect_to "/admin"
+  end
+end

--- a/app/controllers/user_orders_controller.rb
+++ b/app/controllers/user_orders_controller.rb
@@ -14,6 +14,7 @@ class UserOrdersController < ApplicationController
   def update
     @user = User.find(session[:user_id])
     @order = @user.orders.find(params[:order_id])
+
     @order.return_quantity
 
     @order.update(status: 3)

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -7,5 +7,9 @@
     <p><%= link_to order.user.name, "/admin/users/#{order.user.id}" %></p>
     <p>Order ID: <%= order.id %></p>
     <p>Created On: <%= order.created_at.strftime("%m-%d-%Y")%></p>
+    <p><%= order.status %></p>
+    <% if order.status == 'packaged' %>
+    <%= button_to "Ship Order", "/admin/orders/#{order.id}", method: :patch  %>
+    <% end %>
   </section>
 <% end %>

--- a/app/views/user_orders/show.html.erb
+++ b/app/views/user_orders/show.html.erb
@@ -20,5 +20,7 @@
 <p>Total Items Ordered: <%=
    @order.total_quantity %></p>
 <p>Total Cost: <%=number_to_currency(@order.grandtotal)%></p>
+<% if @order.status != 'shipped' %>
 
-<p><%= link_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %></p>
+  <p><%= link_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get '/', to: 'dashboard#index'
+    patch '/orders/:order_id', to: 'orders#update'
   end
 
   get '/profile', to: 'users#show'

--- a/spec/features/admins/index_spec.rb
+++ b/spec/features/admins/index_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe 'On the admin dashboard page' do
                             address: '123 Kevin Ave',
                             city: 'Kevin Town',
                             state: 'FL',
-                            zip: 90909)
+                            zip: 90909,
+                            status: 0)
 
     @tire = @meg.items.create!(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
     @pull_toy = @meg.items.create!(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
@@ -60,4 +61,25 @@ RSpec.describe 'On the admin dashboard page' do
     expect("#{@order_2.id}").to appear_before("#{@order_1.id}")
   end
 
+  it "I can ship any packaged orders and user can no longer cancel it" do
+    visit '/admin'
+
+    within "#order-#{@order_2.id}" do
+      expect(page).to have_button("Ship Order")
+
+      click_button("Ship Order")
+      expect(current_path).to eq("/admin")
+    end
+
+    @order_2.reload
+    expect(@order_2.status).to eq("shipped")
+  end
+
+  it "I can't ship any orders without status of packaged" do
+    visit '/admin'
+
+    within "#order-#{@order_1.id}" do
+      expect(page).to_not have_button("Ship Order")
+    end
+  end
 end

--- a/spec/features/user_orders/show_spec.rb
+++ b/spec/features/user_orders/show_spec.rb
@@ -95,4 +95,16 @@ RSpec.describe 'On the user orders show page' do
 
     expect(page).to have_content("Order Status: cancelled")
   end
+
+  it "If order is shipped, I cannot see a cancel button" do
+    order_3 = @user_1.orders.create!(name: 'Matt',
+                            address: '123 Matt Ave',
+                            city: 'Matt Town',
+                            state: 'FL',
+                            zip: 90909,
+                            status: 2)
+
+    visit "/profile/orders/#{order_3.id}"
+    expect(page).to_not have_link("Cancel Order")
+  end
 end


### PR DESCRIPTION
[x] done

User Story 33, Admin can "ship" an order

As an admin user
When I log into my dashboard, "/admin"
Then I see any "packaged" orders ready to ship.
Next to each order I see a button to "ship" the order.
When I click that button for an order, the status of that order changes to "shipped"
And the user can no longer "cancel" the order.