### PR TITLE
Story46

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -12,7 +12,7 @@ class Merchant::ItemsController < Merchant::BaseController
     else
       item.update(activation_status: 'Deactivated')
       flash[:success] = "#{item.name} was deactivated."
-    end 
+    end
       redirect_to '/merchant/items'
   end
 
@@ -20,9 +20,14 @@ class Merchant::ItemsController < Merchant::BaseController
 
   def create
     @merchant = Merchant.find_by(id: current_user.merchant_id)
-    item = @merchant.items.create(item_params)
-    redirect_to '/merchant/items'
-    flash[:success] = "#{item.name} has been added."
+    @item = @merchant.items.create(item_params)
+    if @item.save
+      redirect_to '/merchant/items'
+      flash[:success] = "#{@item.name} has been added."
+    else
+      flash[:error] = @item.errors.full_messages.to_sentence
+      render :new
+    end
   end
 
   def destroy

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -16,11 +16,26 @@ class Merchant::ItemsController < Merchant::BaseController
       redirect_to '/merchant/items'
   end
 
+  def new;end
+
+  def create
+    @merchant = Merchant.find_by(id: current_user.merchant_id)
+    item = @merchant.items.create(item_params)
+    redirect_to '/merchant/items'
+    flash[:success] = "#{item.name} has been added."
+  end
+
   def destroy
     @merchant = Merchant.find_by(id: current_user.merchant_id)
     item = @merchant.items.find(params[:item_id])
     Item.destroy(params[:item_id])
     redirect_to '/merchant/items'
     flash[:success] = "#{item.name} was deleted."
+  end
+
+  private
+
+  def item_params
+    params.permit(:name, :description, :image, :price, :inventory)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,10 +7,11 @@ class Item < ApplicationRecord
   validates_presence_of :name,
                         :description,
                         :price,
-                        :image,
                         :inventory,
                         :activation_status
   validates_numericality_of :price, greater_than: 0
+  validates_numericality_of :inventory, greater_than: 0
+  validates_presence_of :image, allow_blank: true
 
   def average_review
     reviews.average(:rating)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,5 @@
 class Item < ApplicationRecord
+  before_save :default_picture
   belongs_to :merchant
   has_many :reviews, dependent: :destroy
   has_many :item_orders
@@ -12,6 +13,10 @@ class Item < ApplicationRecord
   validates_numericality_of :price, greater_than: 0
   validates_numericality_of :inventory, greater_than: 0
   validates_presence_of :image, allow_blank: true
+
+  def default_picture
+    self.image = 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/No_image_available.svg/600px-No_image_available.svg.png' if self.image == ''
+  end
 
   def average_review
     reviews.average(:rating)

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -1,5 +1,5 @@
 <h2>My Items</h2>
-
+<%= link_to 'Add Item', '/merchant/items/new', method: :get %>
 <% @merchant.items.each do |item| %>
 <section id="item-<%= item.id %>">
 <p>Name: <%= item.name %></p>
@@ -7,18 +7,18 @@
 <p>Price: <%= number_to_currency(item.price) %></p>
   <%= image_tag(item.image) %>
   <% if item.activation_status == 'Activated' %>
-    <p>Status: Actived</p>
+    <p>Status: Active</p>
   <% else %>
     <p>Status: Inactive</p>
   <% end %>
 <p>Inventory: <%= item.inventory %></p>
 <% if item.activation_status == 'Activated' %>
-  <%= link_to 'Deactivate Item', "merchant/items/#{item.id}", method: :patch %>
+  <%= link_to 'Deactivate Item', "/merchant/items/#{item.id}", method: :patch %>
 <% else %>
-  <%= link_to 'Activate Item', "merchant/items/#{item.id}", method: :patch %>
+  <%= link_to 'Activate Item', "/merchant/items/#{item.id}", method: :patch %>
 <% end %>
 <% if item.item_orders.empty? %>
-  <%= link_to 'Delete Item', "merchant/items/#{item.id}", method: :delete %>
+  <%= link_to 'Delete Item', "/merchant/items/#{item.id}", method: :delete %>
 <% end%>
 </section>
 <% end %>

--- a/app/views/merchant/items/new.html.erb
+++ b/app/views/merchant/items/new.html.erb
@@ -3,19 +3,19 @@
 <center>
   <%= form_tag "/merchant/items", method: :post  do %>
   <%= label_tag :name %>
-  <%= text_field_tag :name%>
+  <%= text_field_tag :name, (if @item.present? then @item.name else nil end)%>
 
   <%= label_tag :description %>
-  <%= text_field_tag :description %>
+  <%= text_field_tag :description, (if @item.present? then @item.description else nil end) %>
 
   <%= label_tag :price %>
-  <%= text_field_tag :price %>
+  <%= text_field_tag :price, (if @item.present? then @item.price else nil end) %>
 
   <%= label_tag :image %>
-  <%= text_field_tag :image %>
+  <%= text_field_tag :image, (if @item.present? then @item.image else nil end) %>
 
   <%= label_tag :inventory %>
-  <%= text_field_tag :inventory %>
+  <%= text_field_tag :inventory, (if @item.present? then @item.inventory else nil end) %>
 
   <%= submit_tag 'Submit' %>
   <% end %>

--- a/app/views/merchant/items/new.html.erb
+++ b/app/views/merchant/items/new.html.erb
@@ -1,0 +1,22 @@
+<h1>Add a New Item</h1>
+
+<center>
+  <%= form_tag "/merchant/items", method: :post  do %>
+  <%= label_tag :name %>
+  <%= text_field_tag :name%>
+
+  <%= label_tag :description %>
+  <%= text_field_tag :description %>
+
+  <%= label_tag :price %>
+  <%= text_field_tag :price %>
+
+  <%= label_tag :image %>
+  <%= text_field_tag :image %>
+
+  <%= label_tag :inventory %>
+  <%= text_field_tag :inventory %>
+
+  <%= submit_tag 'Submit' %>
+  <% end %>
+</center>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,8 +49,10 @@ Rails.application.routes.draw do
   namespace :merchant do
     get '/', to: 'dashboard#index'
     get '/items', to: 'items#index'
-    patch 'merchant/items/:item_id', to: 'items#update'
-    delete 'merchant/items/:item_id', to: 'items#destroy'
+    patch '/items/:item_id', to: 'items#update'
+    delete '/items/:item_id', to: 'items#destroy'
+    get '/items/new', to: 'items#new'
+    post '/items', to: 'items#create'
   end
 
   namespace :admin do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,7 +32,6 @@ ActiveRecord::Schema.define(version: 2020_11_03_034224) do
     t.string "description"
     t.integer "price"
     t.string "image"
-    t.boolean "active?", default: true
     t.integer "inventory"
     t.bigint "merchant_id"
     t.datetime "created_at", null: false

--- a/spec/features/dashboards/admin/merchant_index_spec.rb
+++ b/spec/features/dashboards/admin/merchant_index_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'As a admin' do
 
     it "after clicking on 'disable' all merchants items should be deactivated" do
       brian = Merchant.create!(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
-      dog_bone = brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+      dog_bone = brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", activation_status: 'Deactivated', inventory: 21)
       pull_toy = brian.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
       user_1 = User.create!(name: 'Grant',
                             address: '124 Grant Ave.',
@@ -127,7 +127,7 @@ RSpec.describe 'As a admin' do
 
     it "after clicking on 'enable' all merchants items should be activated" do
       brian = Merchant.create!(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
-      dog_bone = brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+      dog_bone = brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", activation_status: 'Deactivated', inventory: 21)
       pull_toy = brian.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
       user_1 = User.create!(name: 'Grant',
                             address: '124 Grant Ave.',

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "As a Visitor" do
 
         click_button "Update Item"
 
-        expect(page).to have_content("Name can't be blank and Image can't be blank")
+        expect(page).to have_content("Name can't be blank")
         expect(page).to have_button("Update Item")
       end
     end

--- a/spec/features/items/new_spec.rb
+++ b/spec/features/items/new_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe "Create Merchant Items" do
 
       click_button "Create Item"
 
-      expect(page).to have_content("Name can't be blank and Inventory can't be blank")
+      expect(page).to have_content("Name can't be blank")
+      expect(page).to have_content("Inventory can't be blank")
       expect(page).to have_button("Create Item")
     end
   end

--- a/spec/features/merchants/items/destroy_spec.rb
+++ b/spec/features/merchants/items/destroy_spec.rb
@@ -15,34 +15,32 @@ RSpec.describe "Merchant Items Index Page" do
       click_on 'Submit'
     end
 
-    it 'I can see all of the merchant items' do
+    it 'I can delete an item' do
+      dog_bone = @merchant_1.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", activation_status: 'Deactivated', inventory: 21)
+      visit "merchant/items"
+
+      within "#item-#{dog_bone.id}" do
+        expect(page).to have_content(dog_bone.name)
+        expect(page).to have_content("Description: #{dog_bone.description}")
+        expect(page).to have_content(dog_bone.price)
+        expect(page).to have_css("img[src*='#{dog_bone.image}']")
+        expect(page).to have_content("Status: Inactive")
+        expect(page).to have_content("Inventory: #{dog_bone.inventory}")
+        click_on 'Delete Item'
+      end
+      expect(current_path).to eq("/merchant/items")
+      expect(page).to have_content("#{dog_bone.name} was deleted.")
+      expect(page).to_not have_content(dog_bone.description)
+    end
+
+    it 'I can not delete an item if it has ever been ordered' do
+      order_1 = @user_1.orders.create!(name: 'Kevin', address: '123 Kevin Ave', city: 'Kevin Town', state: 'FL', zip: 90909)
+      order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
       visit "merchant/items"
 
       within "#item-#{@tire.id}" do
-        expect(page).to have_content(@tire.name)
-        expect(page).to have_content("Description: #{@tire.description}")
-        expect(page).to have_content(@tire.price)
-        expect(page).to have_css("img[src*='#{@tire.image}']")
-        expect(page).to have_content("Status: Active")
-        expect(page).to have_content("Inventory: #{@tire.inventory}")
-      end
-
-      within "#item-#{@chain.id}" do
-        expect(page).to have_content(@chain.name)
-        expect(page).to have_content("Description: #{@chain.description}")
-        expect(page).to have_content(@chain.price)
-        expect(page).to have_css("img[src*='#{@chain.image}']")
-        expect(page).to have_content("Status: Active")
-        expect(page).to have_content("Inventory: #{@chain.inventory}")
+        expect(page).to_not have_content("Delete Item")
       end
     end
-
-    it 'I can see a link to add a new item' do
-      visit "merchant/items"
-
-      expect(page).to have_link("Add Item")
-      click_link 'Add Item'
-      expect(current_path).to eq("/merchant/items/new")
-    end
-  end
-end 
+  end 
+end

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Merchant Items Index Page" do
       click_on 'Submit'
     end
 
-    it 'I can see all of the merchant items' do
+    it 'I can deactivate active items' do
       visit "merchant/items"
 
       within "#item-#{@tire.id}" do
@@ -34,15 +34,38 @@ RSpec.describe "Merchant Items Index Page" do
         expect(page).to have_css("img[src*='#{@chain.image}']")
         expect(page).to have_content("Status: Active")
         expect(page).to have_content("Inventory: #{@chain.inventory}")
+        click_on 'Deactivate Item'
+        expect(page).to have_content("Status: Inactive")
       end
+      expect(current_path).to eq("/merchant/items")
+      expect(page).to have_content("#{@chain.name} was deactivated.")
     end
 
-    it 'I can see a link to add a new item' do
+    it 'I can activate an inactive items' do
+      dog_bone = @merchant_1.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", activation_status: 'Deactivated', inventory: 21)
       visit "merchant/items"
 
-      expect(page).to have_link("Add Item")
-      click_link 'Add Item'
-      expect(current_path).to eq("/merchant/items/new")
+      within "#item-#{@tire.id}" do
+        expect(page).to have_content(@tire.name)
+        expect(page).to have_content("Description: #{@tire.description}")
+        expect(page).to have_content(@tire.price)
+        expect(page).to have_css("img[src*='#{@tire.image}']")
+        expect(page).to have_content("Status: Active")
+        expect(page).to have_content("Inventory: #{@tire.inventory}")
+      end
+
+      within "#item-#{dog_bone.id}" do
+        expect(page).to have_content(dog_bone.name)
+        expect(page).to have_content("Description: #{dog_bone.description}")
+        expect(page).to have_content(dog_bone.price)
+        expect(page).to have_css("img[src*='#{dog_bone.image}']")
+        expect(page).to have_content("Status: Inactive")
+        expect(page).to have_content("Inventory: #{dog_bone.inventory}")
+        click_on 'Activate Item'
+        expect(page).to have_content("Status: Active")
+      end
+      expect(current_path).to eq("/merchant/items")
+      expect(page).to have_content("#{dog_bone.name} was activated.")
     end
-  end
-end 
+  end 
+end

--- a/spec/features/merchants/items/new_spec.rb
+++ b/spec/features/merchants/items/new_spec.rb
@@ -31,5 +31,17 @@ RSpec.describe "Merchant Items New Page" do
       expect(page).to have_content(item.description)
       expect(item.activation_status).to eq("Activated")
     end
+
+    it 'Returns default image if no image entered' do
+      visit 'merchant/items/new'
+
+      fill_in :name, with: "Bike Backpack"
+      fill_in :description, with: "Black and Yellow"
+      fill_in :inventory, with: 100
+      fill_in :price, with: 40
+      click_on 'Submit'
+      item = Item.last
+      expect(page).to have_css("img[src*='https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/No_image_available.svg/600px-No_image_available.svg.png']")
+    end
   end 
 end 

--- a/spec/features/merchants/items/new_spec.rb
+++ b/spec/features/merchants/items/new_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe "Merchant Items New Page" do
       @chain = @merchant_1.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
       @shifter = @merchant_1.items.create(name: "Shimano Shifters", description: "It'll always shift!", activation_status: 'Deactivated', price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
       @user_1 = @merchant_1.users.create!(name: 'Grant', address: '124 Grant Ave.', city: 'Denver', state: 'CO', zip: 12345, email: 'grant@coolguy.com', password: 'password', role: 1)
-      
+
       visit '/login'
       fill_in :email, with: @user_1.email
       fill_in :password, with: @user_1.password
       click_on 'Submit'
     end
 
-    it 'I can fill out a form to create a new item' do 
+    it 'I can fill out a form to create a new item' do
       visit 'merchant/items/new'
 
       fill_in :name, with: "Bike Backpack"
@@ -43,5 +43,31 @@ RSpec.describe "Merchant Items New Page" do
       item = Item.last
       expect(page).to have_css("img[src*='https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/No_image_available.svg/600px-No_image_available.svg.png']")
     end
-  end 
-end 
+
+    it "I cannot add a new item if details are missing" do
+      visit 'merchant/items/new'
+
+      name = ""
+      price = 18
+      description = "No more chaffin'!"
+      image_url = "https://images-na.ssl-images-amazon.com/images/I/51HMpDXItgL._SX569_.jpg"
+      inventory = ""
+
+      fill_in :name, with: name
+      fill_in :price, with: price
+      fill_in :description, with: description
+      fill_in :image, with: image_url
+      fill_in :inventory, with: inventory
+
+      click_on "Submit"
+
+      expect(page).to have_content("Name can't be blank")
+      expect(page).to have_content("Inventory can't be blank")
+      expect(find_field(:name).value).to eq("")
+      expect(find_field(:price).value).to eq("18")
+      expect(find_field(:description).value).to eq("No more chaffin'!")
+      expect(find_field(:image).value).to eq("https://images-na.ssl-images-amazon.com/images/I/51HMpDXItgL._SX569_.jpg")
+      expect(find_field(:inventory).value).to eq(nil)
+    end
+  end
+end

--- a/spec/features/merchants/items/new_spec.rb
+++ b/spec/features/merchants/items/new_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "Merchant Items New Page" do
       click_on 'Submit'
       item = Item.last
 
-      
       expect(current_path).to eq("/merchant/items")
       expect(page).to have_content("#{item.name} has been added.")
       expect(page).to have_content(item.description)

--- a/spec/features/merchants/items/new_spec.rb
+++ b/spec/features/merchants/items/new_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe "Merchant Items New Page" do
+  describe "When I visit the merchant items new page" do
+    before(:each) do
+      @merchant_1 = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @tire = @merchant_1.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @chain = @merchant_1.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      @shifter = @merchant_1.items.create(name: "Shimano Shifters", description: "It'll always shift!", activation_status: 'Deactivated', price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
+      @user_1 = @merchant_1.users.create!(name: 'Grant', address: '124 Grant Ave.', city: 'Denver', state: 'CO', zip: 12345, email: 'grant@coolguy.com', password: 'password', role: 1)
+      
+      visit '/login'
+      fill_in :email, with: @user_1.email
+      fill_in :password, with: @user_1.password
+      click_on 'Submit'
+    end
+
+    it 'I can fill out a form to create a new item' do 
+      visit 'merchant/items/new'
+
+      fill_in :name, with: "Bike Backpack"
+      fill_in :description, with: "Black and Yellow"
+      fill_in :image, with: "https://images-na.ssl-images-amazon.com/images/I/61dDUwQ0VUL._AC_UX385_.jpg"
+      fill_in :inventory, with: 100
+      fill_in :price, with: 40
+      click_on 'Submit'
+      item = Item.last
+
+      
+      expect(current_path).to eq("/merchant/items")
+      expect(page).to have_content("#{item.name} has been added.")
+      expect(page).to have_content(item.description)
+      expect(item.activation_status).to eq("Activated")
+    end
+  end 
+end 

--- a/spec/features/merchants/statistics_spec.rb
+++ b/spec/features/merchants/statistics_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'merchant show page', type: :feature do
 
       @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
       @pull_toy = @brian.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
-      @dog_bone = @brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 20, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+      @dog_bone = @brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 20, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", activation_status: 'Deactivated', inventory: 21)
 
       @user_1 = User.create!(name: 'Carson', address: '123 Carson Ave.', city: 'Denver', state: 'CO', zip: 12458, email: 'carson@coolchick.com', password: 'password', role: 0)
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,10 +5,10 @@ describe Item, type: :model do
     it { should validate_presence_of :name }
     it { should validate_presence_of :description }
     it { should validate_presence_of :price }
-    it { should validate_presence_of :image }
     it { should validate_presence_of :inventory }
     it { should validate_presence_of :activation_status }
-
+    it { should validate_numericality_of(:inventory).is_greater_than(0) }
+    it { should validate_numericality_of(:price).is_greater_than(0) }
   end
 
   describe "relationships" do


### PR DESCRIPTION
[x] done

User Story 46, Merchant cannot add an item if details are bad/missing

As a merchant employee
When I try to add a new item
If any of my data is incorrect or missing (except image)
Then I am returned to the form
I see one or more flash messages indicating each error I caused
All fields are re-populated with my previous data