### PR TITLE
Story 47 and Story 48

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -3,19 +3,6 @@ class Merchant::ItemsController < Merchant::BaseController
     @merchant = Merchant.find_by(id: current_user.merchant_id)
   end
 
-  def update
-    @merchant = Merchant.find_by(id: current_user.merchant_id)
-    item = Item.find(params[:item_id])
-    if item.activation_status == 'Deactivated'
-      item.update(activation_status: 'Activated')
-      flash[:success] = "#{item.name} was activated."
-    else
-      item.update(activation_status: 'Deactivated')
-      flash[:success] = "#{item.name} was deactivated."
-    end
-      redirect_to '/merchant/items'
-  end
-
   def new;end
 
   def create
@@ -29,6 +16,37 @@ class Merchant::ItemsController < Merchant::BaseController
       render :new
     end
   end
+  def change_status
+    @merchant = Merchant.find_by(id: current_user.merchant_id)
+    item = Item.find(params[:item_id])
+    if item.activation_status == 'Deactivated'
+      item.update(activation_status: 'Activated')
+      flash[:success] = "#{item.name} was activated."
+    else
+      item.update(activation_status: 'Deactivated')
+      flash[:success] = "#{item.name} was deactivated."
+    end
+    redirect_to '/merchant/items'
+  end
+
+  def edit
+    @merchant = Merchant.find_by(id: current_user.merchant_id)
+    @item = @merchant.items.find(params[:item_id])
+  end
+
+  def update
+    @merchant = Merchant.find_by(id: current_user.merchant_id)
+    @item = @merchant.items.find(params[:item_id])
+    @item.update(item_params)
+    if @item.save
+      flash[:success] = "#{@item.name} has been updated."
+      redirect_to "/merchant/items"
+    else
+      flash[:error] = @item.errors.full_messages.to_sentence
+      render :edit
+    end
+  end
+
 
   def destroy
     @merchant = Merchant.find_by(id: current_user.merchant_id)

--- a/app/views/merchant/items/edit.html.erb
+++ b/app/views/merchant/items/edit.html.erb
@@ -1,0 +1,22 @@
+<h1>Edit: <%= @item.name %></h1>
+
+<center>
+  <%= form_tag "/merchant/items/#{@item.id}/edit", method: :patch  do %>
+    <%= label_tag :name %>
+    <%= text_field_tag :name, "#{@item.name}"%>
+
+    <%= label_tag :description %>
+    <%= text_field_tag :description, "#{@item.description}" %>
+
+    <%= label_tag :price %>
+    <%= text_field_tag :price, "#{number_to_currency(@item.price)}" %>
+
+    <%= label_tag :image %>
+    <%= text_field_tag :image, "#{@item.image}" %>
+
+    <%= label_tag :inventory %>
+    <%= text_field_tag :inventory, "#{@item.inventory}" %>
+
+    <%= submit_tag 'Submit' %>
+  <% end %>
+</center>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -17,6 +17,9 @@
 <% else %>
   <%= link_to 'Activate Item', "/merchant/items/#{item.id}", method: :patch %>
 <% end %>
+
+<%= link_to 'Edit Item', "/merchant/items/#{item.id}/edit", method: :get %>
+
 <% if item.item_orders.empty? %>
   <%= link_to 'Delete Item', "/merchant/items/#{item.id}", method: :delete %>
 <% end%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,10 +49,12 @@ Rails.application.routes.draw do
   namespace :merchant do
     get '/', to: 'dashboard#index'
     get '/items', to: 'items#index'
-    patch '/items/:item_id', to: 'items#update'
-    delete '/items/:item_id', to: 'items#destroy'
     get '/items/new', to: 'items#new'
     post '/items', to: 'items#create'
+    patch '/items/:item_id', to: 'items#change_status'
+    get '/items/:item_id/edit', to: 'items#edit'
+    patch '/items/:item_id/edit', to: 'items#update'
+    delete '/items/:item_id', to: 'items#destroy'
   end
 
   namespace :admin do

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -1,71 +1,83 @@
 require 'rails_helper'
 
-RSpec.describe "Merchant Items Index Page" do
-  describe "When I visit the merchant items page" do
+RSpec.describe "As a Merchant Employee" do
+  describe "When I visit an Item Edit Page" do
     before(:each) do
       @merchant_1 = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @tire = @merchant_1.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
       @chain = @merchant_1.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
       @shifter = @merchant_1.items.create(name: "Shimano Shifters", description: "It'll always shift!", activation_status: 'Deactivated', price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
       @user_1 = @merchant_1.users.create!(name: 'Grant', address: '124 Grant Ave.', city: 'Denver', state: 'CO', zip: 12345, email: 'grant@coolguy.com', password: 'password', role: 1)
-      
+
       visit '/login'
       fill_in :email, with: @user_1.email
       fill_in :password, with: @user_1.password
       click_on 'Submit'
     end
 
-    it 'I can deactivate active items' do
-      visit "merchant/items"
+    it 'I can see the prepopulated fields of that item' do
+      visit "/merchant/items/#{@tire.id}/edit"
 
-      within "#item-#{@tire.id}" do
-        expect(page).to have_content(@tire.name)
-        expect(page).to have_content("Description: #{@tire.description}")
-        expect(page).to have_content(@tire.price)
-        expect(page).to have_css("img[src*='#{@tire.image}']")
-        expect(page).to have_content("Status: Active")
-        expect(page).to have_content("Inventory: #{@tire.inventory}")
-      end
-
-      within "#item-#{@chain.id}" do
-        expect(page).to have_content(@chain.name)
-        expect(page).to have_content("Description: #{@chain.description}")
-        expect(page).to have_content(@chain.price)
-        expect(page).to have_css("img[src*='#{@chain.image}']")
-        expect(page).to have_content("Status: Active")
-        expect(page).to have_content("Inventory: #{@chain.inventory}")
-        click_on 'Deactivate Item'
-        expect(page).to have_content("Status: Inactive")
-      end
-      expect(current_path).to eq("/merchant/items")
-      expect(page).to have_content("#{@chain.name} was deactivated.")
+      expect(find_field(:name).value).to eq "Gatorskins"
+      expect(find_field(:price).value).to eq '$100.00'
+      expect(find_field(:description).value).to eq "They'll never pop!"
+      expect(find_field(:image).value).to eq("https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588")
+      expect(find_field(:inventory).value).to eq '12'
     end
 
-    it 'I can activate an inactive items' do
-      dog_bone = @merchant_1.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", activation_status: 'Deactivated', inventory: 21)
-      visit "merchant/items"
+    it "I can edit a form" do
+      visit "/merchant/items/#{@tire.id}/edit"
 
-      within "#item-#{@tire.id}" do
-        expect(page).to have_content(@tire.name)
-        expect(page).to have_content("Description: #{@tire.description}")
-        expect(page).to have_content(@tire.price)
-        expect(page).to have_css("img[src*='#{@tire.image}']")
-        expect(page).to have_content("Status: Active")
-        expect(page).to have_content("Inventory: #{@tire.inventory}")
-      end
+      fill_in 'Name', with: "LizardSkins"
+      fill_in 'Price', with: 14
+      fill_in 'Description', with: "They're a bit more expensive, and they kinda do pop sometimes, but whatevs.. this is retail."
+      fill_in 'Image', with: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588"
+      fill_in 'Inventory', with: 114
 
-      within "#item-#{dog_bone.id}" do
-        expect(page).to have_content(dog_bone.name)
-        expect(page).to have_content("Description: #{dog_bone.description}")
-        expect(page).to have_content(dog_bone.price)
-        expect(page).to have_css("img[src*='#{dog_bone.image}']")
-        expect(page).to have_content("Status: Inactive")
-        expect(page).to have_content("Inventory: #{dog_bone.inventory}")
-        click_on 'Activate Item'
-        expect(page).to have_content("Status: Active")
-      end
+      click_on "Submit"
+
       expect(current_path).to eq("/merchant/items")
-      expect(page).to have_content("#{dog_bone.name} was activated.")
+      expect(page).to have_content("LizardSkins")
+      expect(page).to have_content("$14.00")
+      expect(page).to have_content("They're a bit more expensive, and they kinda do pop sometimes, but whatevs.. this is retail.")
+      expect(page).to have_css("img[src*='https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588']")
+      expect(page).to have_content("114")
+
+      expect(page).to_not have_content("Gatorskins")
+
+      @tire.reload
+      expect(page).to have_content("#{@tire.name} has been updated.")
+      expect(@tire.activation_status).to eq("Activated")
     end
-  end 
+
+    it 'I get a flash message if entire form is not filled out' do
+      visit "/merchant/items/#{@tire.id}/edit"
+
+      fill_in 'Name', with: ""
+      fill_in 'Price', with: 0
+      fill_in 'Description', with: ""
+      fill_in 'Image', with: ""
+      fill_in 'Inventory', with: 1
+
+      click_button "Submit"
+
+      expect(page).to have_content("Name can't be blank")
+      expect(page).to have_content("Description can't be blank")
+      expect(page).to have_content("Price must be greater than 0")
+    end
+
+    it "I see default image if no image is entered" do
+      visit "/merchant/items/#{@tire.id}/edit"
+
+      fill_in 'Name', with: "LizardSkins"
+      fill_in 'Price', with: 14
+      fill_in 'Description', with: "They're a bit more expensive, and they kinda do pop sometimes, but whatevs.. this is retail."
+      fill_in 'Image', with: ""
+      fill_in 'Inventory', with: 114
+
+      click_on "Submit"
+
+      expect(page).to have_css("img[src*='https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/No_image_available.svg/600px-No_image_available.svg.png']")
+    end
+  end
 end

--- a/spec/features/merchants/items/new_spec.rb
+++ b/spec/features/merchants/items/new_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe "Merchant Items New Page" do
 
       expect(page).to have_content("Name can't be blank")
       expect(page).to have_content("Inventory can't be blank")
+
       expect(find_field(:name).value).to eq("")
       expect(find_field(:price).value).to eq("18")
       expect(find_field(:description).value).to eq("No more chaffin'!")

--- a/spec/features/merchants/items/update_status_spec.rb
+++ b/spec/features/merchants/items/update_status_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe "Merchant Items Index Page" do
       @chain = @merchant_1.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
       @shifter = @merchant_1.items.create(name: "Shimano Shifters", description: "It'll always shift!", activation_status: 'Deactivated', price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
       @user_1 = @merchant_1.users.create!(name: 'Grant', address: '124 Grant Ave.', city: 'Denver', state: 'CO', zip: 12345, email: 'grant@coolguy.com', password: 'password', role: 1)
-
+      
       visit '/login'
       fill_in :email, with: @user_1.email
       fill_in :password, with: @user_1.password
       click_on 'Submit'
     end
 
-    it 'I can see all of the merchant items' do
+    it 'I can deactivate active items' do
       visit "merchant/items"
 
       within "#item-#{@tire.id}" do
@@ -34,30 +34,38 @@ RSpec.describe "Merchant Items Index Page" do
         expect(page).to have_css("img[src*='#{@chain.image}']")
         expect(page).to have_content("Status: Active")
         expect(page).to have_content("Inventory: #{@chain.inventory}")
+        click_on 'Deactivate Item'
+        expect(page).to have_content("Status: Inactive")
       end
+      expect(current_path).to eq("/merchant/items")
+      expect(page).to have_content("#{@chain.name} was deactivated.")
     end
 
-    it 'I can see a link to add a new item' do
-      visit "merchant/items"
-
-      expect(page).to have_link("Add Item")
-      click_link 'Add Item'
-      expect(current_path).to eq("/merchant/items/new")
-    end
-
-    it 'I can see a link to edit an item' do
+    it 'I can activate an inactive items' do
+      dog_bone = @merchant_1.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", activation_status: 'Deactivated', inventory: 21)
       visit "merchant/items"
 
       within "#item-#{@tire.id}" do
-        expect(page).to have_link("Edit Item")
+        expect(page).to have_content(@tire.name)
+        expect(page).to have_content("Description: #{@tire.description}")
+        expect(page).to have_content(@tire.price)
+        expect(page).to have_css("img[src*='#{@tire.image}']")
+        expect(page).to have_content("Status: Active")
+        expect(page).to have_content("Inventory: #{@tire.inventory}")
       end
 
-      within "#item-#{@chain.id}" do
-        expect(page).to have_link("Edit Item")
-        click_link('Edit Item')
-
-        expect(current_path).to eq("/merchant/items/#{@chain.id}/edit")
+      within "#item-#{dog_bone.id}" do
+        expect(page).to have_content(dog_bone.name)
+        expect(page).to have_content("Description: #{dog_bone.description}")
+        expect(page).to have_content(dog_bone.price)
+        expect(page).to have_css("img[src*='#{dog_bone.image}']")
+        expect(page).to have_content("Status: Inactive")
+        expect(page).to have_content("Inventory: #{dog_bone.inventory}")
+        click_on 'Activate Item'
+        expect(page).to have_content("Status: Active")
       end
+      expect(current_path).to eq("/merchant/items")
+      expect(page).to have_content("#{dog_bone.name} was activated.")
     end
-  end
+  end 
 end


### PR DESCRIPTION
[x] done

User Story 47, Merchant edits an item

As a merchant employee
When I visit my items page
And I click the edit button or link next to any item
Then I am taken to a form similar to the 'new item' form
The form is pre-populated with all of this item's information
I can change any information, but all of the rules for adding a new item still apply:
- name and description cannot be blank
- price cannot be less than $0.00
- inventory must be 0 or greater

When I submit the form
I am taken back to my items page
I see a flash message indicating my item is updated
I see the item's new information on the page, and it maintains its previous enabled/disabled state
If I left the image field blank, I see a placeholder image for the thumbnail

[x] done

User Story 48, Merchant cannot edit an item if details are bad/missing

As a merchant employee
When I try to edit an existing item
If any of my data is incorrect or missing (except image)
Then I am returned to the form
I see one or more flash messages indicating each error I caused
All fields are re-populated with my previous data