### PR TITLE
Story53

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,9 @@
+class Admin::UsersController < Admin::BaseController
+  def index
+    @users = User.all
+  end
+
+  def show
+
+  end
+end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,9 @@
+<h1>All Users</h1>
+
+<% @users.each do |user| %>
+  <section id= "user-<%= user.id %>">
+    <h2><%=link_to user.name, "/admin/users/#{user.id}"%></h2>
+    <p>Created On: <%= user.created_at.strftime("%m-%d-%Y")%></p>
+    <p>Role: <%= user.role %></p>
+  </section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,10 +59,15 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get '/', to: 'dashboard#index'
+
     patch '/orders/:order_id', to: 'orders#update'
+
     get '/merchants', to: 'merchants#index'
     get '/merchants/:id', to: 'merchants#show'
     patch '/merchants/:id', to: 'merchants#update'
+
+    get '/users', to: 'users#index'
+    get '/users/:user_id', to: 'users#show'
   end
 
   get '/profile', to: 'users#show'

--- a/spec/features/admins/index_spec.rb
+++ b/spec/features/admins/index_spec.rb
@@ -82,4 +82,10 @@ RSpec.describe 'On the admin dashboard page' do
       expect(page).to_not have_button("Ship Order")
     end
   end
+
+  it "I can click the users nav link and am taken to admin users index page" do
+    click_on "All Users"
+
+    expect(current_path).to eq("/admin/users")
+  end
 end

--- a/spec/features/admins/users/index_spec.rb
+++ b/spec/features/admins/users/index_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'As an admin' do
+  describe 'When I visit the Users Index Page' do
+    before :each do
+      @admin_1 = User.create!(name: 'Mr. Peanutbutter',
+                              address: '123 Butter Ave.',
+                              city: 'Los Angeles',
+                              state: 'LA',
+                              zip: 12458,
+                              email: 'whodatdog@coolchick.com',
+                              password: 'password',
+                              role: 2)
+
+      @user_1 = User.create!(name: 'Carson',
+                            address: '123 Carson Ave.',
+                            city: 'Denver',
+                            state: 'CO',
+                            zip: 12458,
+                            email: 'carson@coolchick.com',
+                            password: 'password',
+                            role: 0)
+      @user_2 = User.create!(name: 'Hanna',
+                            address: '123 Hanna Ave.',
+                            city: 'Denver',
+                            state: 'CO',
+                            zip: 12453,
+                            email: 'hanna@coolchick.com',
+                            password: 'password',
+                            role: 1)
+      visit '/login'
+
+      fill_in :email, with: @admin_1.email
+      fill_in :password, with: @admin_1.password
+      click_on 'Submit'
+    end
+    it "I see all users, the date they registered and their role" do
+      visit '/admin/users'
+
+      within "#user-#{@user_1.id}" do
+        expect(page).to have_link("#{@user_1.name}")
+        expect(page).to have_content(@user_1.created_at.strftime("%m-%d-%Y"))
+        expect(page).to have_content(@user_1.role)
+      end
+
+      within "#user-#{@user_2.id}" do
+        expect(page).to have_link("#{@user_2.name}")
+        expect(page).to have_content(@user_2.created_at.strftime("%m-%d-%Y"))
+        expect(page).to have_content(@user_2.role)
+
+        click_link("#{@user_2.name}")
+        expect(current_path).to eq("/admin/users/#{@user_2.id}")
+      end
+    end
+  end
+end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -226,6 +226,7 @@ RSpec.describe 'Site Navigation' do
 
         click_on "Submit"
 
+        expect(page).to_not have_content("All Users")
         visit "/merchant"
 
         expect(page).to have_content("The page you were looking for doesn't exist (404)")
@@ -233,6 +234,7 @@ RSpec.describe 'Site Navigation' do
         visit "/admin"
 
         expect(page).to have_content("The page you were looking for doesn't exist (404)")
+
       end
     end
     describe "As a merchant user" do


### PR DESCRIPTION
[x] done

User Story 53, Admin User Index Page

As an admin user
When I click the "Users" link in the nav (only visible to admins)
Then my current URI route is "/admin/users"
Only admin users can reach this path.
I see all users in the system
Each user's name is a link to a show page for that user ("/admin/users/5")
Next to each user's name is the date they registered
Next to each user's name I see what type of user they are