### PR TITLE
Story49 50

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -25,6 +25,21 @@ class OrdersController < ApplicationController
     end
   end
 
+  def update
+    @item = Item.find(params[:id])
+    @item_order = ItemOrder.find_by(item_id: params[:id])
+    if @item.inventory >= @item_order.quantity
+      @item.fill_status = "Fulfilled"
+      @item.update(inventory: (@item.inventory - @item_order.quantity))
+      @item.save
+      flash[:notice] = "#{@item_order.id} has been fulfilled."
+      redirect_to "/merchant/orders/#{@item_order.order_id}"
+    else
+      flash[:notice] = "#{@item_order.id} cannot be fulfilled due to lack of inventory."
+      redirect_to "/merchant/orders/#{@item_order.order_id}"
+    end
+  end
+
   private
 
   def order_params

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -33,6 +33,19 @@
     <section id = "item-<%=item_order.item_id%>">
         <td><p><%=link_to item_order.item.name, "/items/#{item_order.item_id}"%></p></td>
         <td><p><%= link_to item_order.item.merchant.name, "/merchants/#{item_order.item.merchant.id}"%></p></td>
+        <% if current_user && current_user.role == "merchant" %>
+        <section id=item_order.item>
+          <td><p><%= item_order.item.image %></p></td>
+          <td><p><%= item_order.item.price %></p></td>
+          <td><p><%= item_order.quantity %></p></td>
+            <% if item_order.item.fill_status == "Unfulfilled" %>
+              <td><p><%= link_to "fulfill", "/merchant/orders/#{item_order.item_id}", method: :patch %></p></td>
+            <% else %>
+              <td><p><%= item_order.item.fill_status %></p></td>
+            <% end %>
+        </section>
+        <% elsif current_user && current_user.role == "admin" %>
+        <% end %>
         <td><p><%= number_to_currency(item_order.price)%></p></td>
         <td><p><%= item_order.quantity%></p></td>
         <td><p><%= number_to_currency(item_order.subtotal)%></p></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,6 @@ Rails.application.routes.draw do
 
   get '/items/:item_id/reviews/new', to: 'reviews#new'
   post '/items/:item_id/reviews', to: 'reviews#create'
-
   get '/reviews/:id/edit', to: 'reviews#edit'
   patch '/reviews/:id', to: 'reviews#update'
   delete '/reviews/:id', to: 'reviews#destroy'
@@ -56,6 +55,9 @@ Rails.application.routes.draw do
     patch '/items/:item_id/edit', to: 'items#update'
     delete '/items/:item_id', to: 'items#destroy'
   end
+
+  get 'merchant/orders/:id', to: 'orders#show'
+  patch "merchant/orders/:id", to: 'orders#update'
 
   namespace :admin do
     get '/', to: 'dashboard#index'

--- a/db/migrate/20201105014108_add_fill_status_to_items.rb
+++ b/db/migrate/20201105014108_add_fill_status_to_items.rb
@@ -1,0 +1,5 @@
+class AddFillStatusToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :fill_status, :string, default: "Unfulfilled"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_03_034224) do
+ActiveRecord::Schema.define(version: 2020_11_05_014108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2020_11_03_034224) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "activation_status", default: "Activated"
+    t.string "fill_status", default: "Unfulfilled"
     t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -22,6 +22,92 @@ RSpec.describe 'merchant show page', type: :feature do
 
       expect(current_path).to eq("/merchants/#{@bike_shop.id}/items")
     end
+  end
+  describe "As a merchant" do
+    it "Merchant sees an order show page with only the items bought from that merchant including the items name(which is a link to item's show page), image, price, and quantity the user wants to purchase" do
+      meg = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80_203)
+      user_1 = meg.users.create!(name: 'Grant',
+                                 address: '124 Grant Ave.',
+                                 city: 'Denver',
+                                 state: 'CO',
+                                 zip: 12_345,
+                                 email: 'grant@coolguy.com',
+                                 password: 'password',
+                                 role: 1)
 
+      tire = meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
+      toilet_paper = meg.items.create!(name: "Toilet Paper", description: "Your butt will love it!", price: 21, image: "https://cdn.shopify.com/s/files/1/1320/9925/products/WGAC_ProductPhotos_2018Packaging_TransparentBG_DLSingleRoll_large.png?v=1578973373", inventory: 12)
+      order_1 = user_1.orders.create!(name: 'Matt', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033)
+      item_order_1 = order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2)
+      item_order_2 = order_1.item_orders.create!(item: toilet_paper, price: toilet_paper.price, quantity: 1)
+
+      visit '/'
+
+      click_link 'Log In'
+
+      expect(current_path).to eq('/login')
+
+      fill_in :email, with: user_1.email
+      fill_in :password, with: user_1.password
+
+      click_on 'Submit'
+
+      visit '/merchant'
+
+      click_link "Order #{order_1.id}"
+
+      expect(current_path).to eq("/merchant/orders/#{order_1.id}")
+      expect(page).to have_link(tire.name)
+      expect(page).to have_content(tire.image)
+      expect(page).to have_content(tire.price)
+      expect(page).to have_content(item_order_1.quantity)
+
+      expect(page).to have_link(toilet_paper.name)
+      expect(page).to have_content(toilet_paper.image)
+      expect(page).to have_content(toilet_paper.price)
+      expect(page).to have_content(item_order_2.quantity)
+    end
+    it "Merchant fulfills part of an order" do
+        meg = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80_203)
+        user_1 = meg.users.create!(name: 'Grant',
+                                   address: '124 Grant Ave.',
+                                   city: 'Denver',
+                                   state: 'CO',
+                                   zip: 12_345,
+                                   email: 'grant@coolguy.com',
+                                   password: 'password',
+                                   role: 1)
+
+        tire = meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
+        toilet_paper = meg.items.create!(name: "Toilet Paper", description: "Your butt will love it!", price: 21, image: "https://cdn.shopify.com/s/files/1/1320/9925/products/WGAC_ProductPhotos_2018Packaging_TransparentBG_DLSingleRoll_large.png?v=1578973373", inventory: 12)
+        order_1 = user_1.orders.create!(name: 'Matt', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033)
+        item_order_1 = order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2)
+        item_order_2 = order_1.item_orders.create!(item: toilet_paper, price: toilet_paper.price, quantity: 1)
+
+        visit '/'
+
+        click_link 'Log In'
+
+        expect(current_path).to eq('/login')
+
+        fill_in :email, with: user_1.email
+        fill_in :password, with: user_1.password
+
+        click_on 'Submit'
+
+        visit '/merchant'
+
+        click_link "Order #{order_1.id}"
+
+        within "#item-#{tire.id}" do
+          click_link "fulfill"
+        end
+
+        expect(current_path).to eq("/merchant/orders/#{order_1.id}")
+
+        expect(page).to have_content("#{item_order_1.id} has been fulfilled.")
+        tire.reload
+        expect(tire.inventory).to eq(10)
+    end
   end
 end


### PR DESCRIPTION
[ x ] done
 
User Story 49, Merchant sees an order show page
 
As a merchant employee
When I visit an order show page from my dashboard
I see the recipients name and address that was used to create this order
I only see the items in the order that are being purchased from my merchant
I do not see any items in the order being purchased from other merchants
For each item, I see the following information:
- the name of the item, which is a link to my item's show page
- an image of the item
- my price for the item
- the quantity the user wants to purchase

[ x ] done
 
User Story 50, Merchant fulfills part of an order
 
As a merchant employee
When I visit an order show page from my dashboard
For each item of mine in the order
If the user's desired quantity is equal to or less than my current inventory quantity for that item
And I have not already "fulfilled" that item:
- Then I see a button or link to "fulfill" that item
- When I click on that link or button I am returned to the order show page
- I see the item is now fulfilled
- I also see a flash message indicating that I have fulfilled that item
- the item's inventory quantity is permanently reduced by the user's desired quantity
 
If I have already fulfilled this item, I see text indicating such.



